### PR TITLE
Add capability to get streaming URL

### DIFF
--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -249,20 +249,22 @@ class Arlo extends EventEmitter {
             label = 'node-arlo';
         }
 
-        let parent = this.devices[device.parentId];
-        let transId = label + '-' + device.deviceId + '!stream-' + Date.now();
+        let deviceId = device.device.deviceId;
+        let parentId = device.device.parentId;
+        let cloudId = device.device.xCloudId;
 
+        let transId = label + '-' + deviceId + '!stream-' + Date.now();
         let body = {
             [Constants.FROM]       : this.userId + "_web",
-            [Constants.TO]         : parent.id,
+            [Constants.TO]         : parentId,
             [Constants.ACTION]     : Constants.ACTION_SET,
-            [Constants.RESOURCE]   : Constants.RESOURCE_CAMERAS + "/" + device.deviceId,
+            [Constants.RESOURCE]   : Constants.RESOURCE_CAMERAS + "/" + deviceId,
             [Constants.PUBLISH]    : true,
             [Constants.TRANS_ID]   : transId,
-            [Constants.PROPERTIES] : {[Constants.ACTIVITY_STATE]: "startUserStream", [Constants.CAMERA_ID]: device.deviceId}
+            [Constants.PROPERTIES] : {[Constants.ACTIVITY_STATE]: "startUserStream", [Constants.CAMERA_ID]: deviceId}
         }
 
-        this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: parent.cloudId}, callback);
+        this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: cloudId}, callback);
     }
 
     notify(device, body, callback) {

--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -250,9 +250,11 @@ class Arlo extends EventEmitter {
             label = 'node-arlo';
         }
 
-        let deviceId = device.device.deviceId;
-        let parentId = device.device.parentId;
-        let cloudId = device.device.xCloudId;
+        debug('Device: %O', device);
+
+        let deviceId = device.deviceId;
+        let parentId = device.parentId;
+        let cloudId = device.xCloudId;
 
         let transId = label + '-' + deviceId + '!stream-' + Date.now();
         let body = {

--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -262,11 +262,12 @@ class Arlo extends EventEmitter {
             [Constants.PUBLISH]    : true,
             [Constants.TRANS_ID]   : transId,
             [Constants.PROPERTIES] : {[Constants.ACTIVITY_STATE]: "startUserStream", [Constants.CAMERA_ID]: deviceId}
-        }
-
+        };
+        debug('Getting stream');
         this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: cloudId}, function(error, response, body) {
                 debug(body);
                 if (typeof(callback) == 'function') {
+                    debug('Got stream URL: %s', body.data.url);
                     callback(body.data.url);
                     callback = undefined;
                 }

--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -269,13 +269,18 @@ class Arlo extends EventEmitter {
 
         debug('Getting stream');
         this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: cloudId}, function(error, response, body) {
-                if (typeof(callback) == 'function') {
-                    let url = body.data.url.replace('rtsp://','rtsps://');
-                    debug('Got stream URL: %s', url);
-                    callback(url);
-                    callback = undefined;
-                }
-            });
+            if (error || body.data.url === null || body.data.url === undefined) {
+                debug('Error getting stream: %O', error);
+                return;
+            }
+
+            if (typeof(callback) == 'function') {
+                let url = body.data.url.replace('rtsp://','rtsps://');
+                debug('Got stream URL: %s', url);
+                callback(url);
+                callback = undefined;
+            }
+        });
     }
 
     notify(device, body, callback) {

--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -3,7 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 const Extend = require('util')._extend;
 const Request = require('request');
-const debug = require('debug')('Arlo');
+const debug = require('debug')('Node-Arlo');
 const debugComm = require('debug')('Arlo:REST');
 
 const Constants = require('./ArloConstants');
@@ -264,12 +264,13 @@ class Arlo extends EventEmitter {
             [Constants.TRANS_ID]   : transId,
             [Constants.PROPERTIES] : {[Constants.ACTIVITY_STATE]: "startUserStream", [Constants.CAMERA_ID]: deviceId}
         };
+
         debug('Getting stream');
         this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: cloudId}, function(error, response, body) {
-                debug(body);
                 if (typeof(callback) == 'function') {
-                    debug('Got stream URL: %s', body.data.url);
-                    callback(body.data.url);
+                    let url = body.data.url.replace('rtsp://','rtsps://');
+                    debug('Got stream URL: %s', url);
+                    callback(url);
                     callback = undefined;
                 }
             });
@@ -296,7 +297,7 @@ class Arlo extends EventEmitter {
         Request(
             {url: url, method: HTTP_GET, json: true, jar: true, headers: Extend(headers || {}, this.headers)},
             function (error, response, body) {
-                debug(body);
+                debugComm(body);
 
                 if (typeof(callback) == 'function') {
                     callback(error, response, body);

--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events').EventEmitter;
 const Extend = require('util')._extend;
 const Request = require('request');
 const debug = require('debug')('Arlo');
+const debugComm = require('debug')('Arlo:REST');
 
 const Constants = require('./ArloConstants');
 const ArloBaseStation = require('./ArloBaseStation');
@@ -305,11 +306,11 @@ class Arlo extends EventEmitter {
     }
 
     _post(url, body, headers, callback) {
-        debug({url: url, method: HTTP_POST, body: body, json:true, jar: true, headers: Extend(headers || {}, this.headers)});
+        debugComm({url: url, method: HTTP_POST, body: body, json:true, jar: true, headers: Extend(headers || {}, this.headers)});
         Request(
             {url: url, method: HTTP_POST, body: body, json:true, jar: true, headers: Extend(headers || {}, this.headers)},
             function (error, response, body) {
-                debug(body);
+                debugComm(body);
 
                 if (typeof(callback) == 'function') {
                     callback(error, response, body);

--- a/lib/Arlo.js
+++ b/lib/Arlo.js
@@ -264,7 +264,13 @@ class Arlo extends EventEmitter {
             [Constants.PROPERTIES] : {[Constants.ACTIVITY_STATE]: "startUserStream", [Constants.CAMERA_ID]: deviceId}
         }
 
-        this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: cloudId}, callback);
+        this._post(Constants.WEB.STREAM, body, {[Constants.XCLOUD_ID]: cloudId}, function(error, response, body) {
+                debug(body);
+                if (typeof(callback) == 'function') {
+                    callback(body.data.url);
+                    callback = undefined;
+                }
+            });
     }
 
     notify(device, body, callback) {

--- a/lib/ArloBaseStation.js
+++ b/lib/ArloBaseStation.js
@@ -3,6 +3,7 @@
 const EventEmitter = require('events').EventEmitter;
 
 const Constants = require('./ArloConstants');
+const debug = require('debug')('Arlo:BaseStation');
 
 class ArloBaseStation extends EventEmitter {
     constructor(device, parent) {

--- a/lib/ArloCamera.js
+++ b/lib/ArloCamera.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const EventEmitter = require('events').EventEmitter;
+const debug = require('debug')('Arlo:Camera');
 
 const Constants = require('./ArloConstants');
 
@@ -43,10 +44,12 @@ class ArloCamera extends EventEmitter {
     }
 
     getSnapshot(callback) {
+        debug('Get snapshot');
         this.parent.getSnapshot(this.device, callback);
     }
 
     getStream(callback) {
+        debug('Get stream');
         this.parent.getStream(this.device, callback);
     }
 


### PR DESCRIPTION
This pull request implements the `getStream` function, in that the function will now return a functional `rtsps://` stream URL in the callback.

This PR enables a comparable PR in the homebridge-arlo repo: [PR #18](https://github.com/devbobo/homebridge-arlo/pull/18)